### PR TITLE
Create path function & player path with start and end

### DIFF
--- a/rusting-raceway/src/gameplay.rs
+++ b/rusting-raceway/src/gameplay.rs
@@ -8,8 +8,9 @@ pub fn game_plugin(app: &mut App) {
     app.add_systems(
         OnEnter(states::GameState::Matchmaking), //TODO: create a matchmaking screen between game screen and move game setup here to OnEnter(gamestate::InGame)
             (
-                spawn_stadium, 
-                spawn_players.after(spawn_stadium),
+                calculate_paths,
+                spawn_stadium.after(calculate_paths), 
+                spawn_players.after(calculate_paths),
                 networking::start_matchbox_socket.run_if(p2p_mode)
             )
         )
@@ -26,20 +27,41 @@ pub fn game_plugin(app: &mut App) {
         .add_systems(OnExit(states::GameState::InGame), despawn_screen::<components::OnGameScreen>);
 }
 
+/// Calculate paths
+fn calculate_paths(mut commands: Commands) {
+    let mut paths: resources::Paths = Default::default();
+
+    // Stadium dimensions
+    let length = 500.;
+    let inner_radius = 225.;
+    let bend_sections: u32 = 20;
+    let num_paths = 6; // inner stadium, player tracks, and then outer stadium
+    debug_assert!(bend_sections % 2 == 0, "Section size needs to be even to preserve symmetry");
+    debug_assert!(bend_sections > 2, "Section size needs to be greater than 2");
+
+    // Calculate paths
+    let ratio_increase = 1. / (num_paths as f32 + 1.);
+    for path_no in 0..num_paths {
+        let ratio = 1. + path_no as f32 * ratio_increase;
+        paths.0.push(physics::determine_player_path(
+            bend_sections, 
+            Vec3::new(0., inner_radius * ratio, 0.), 
+            Vec3::new(0., - inner_radius * ratio, 0.),
+            length, 
+            inner_radius * ratio
+        )); 
+    }
+
+    commands.insert_resource(paths);
+}
+
 /// Spawn stadium
 fn spawn_stadium(
     mut commands: Commands, 
-    mut paths: ResMut<resources::Paths>,
+    paths: Res<resources::Paths>,
     mut polyline_materials: ResMut<Assets<PolylineMaterial>>,
     mut polylines: ResMut<Assets<Polyline>>,
 ) {
-    let length = 500.;
-    let inner_radius = 225.;
-    let radius_ratio = 2.; // ratio between inner and outer radius
-    let bend_sections: u32 = 20;
-    let num_tracks = 4;
-    debug_assert!(bend_sections % 2 == 0, "Section size needs to be even to preserve symmetry");
-    debug_assert!(bend_sections > 2, "Section size needs to be greater than 2");
 
     // Spawn grass
     let grass_color = Color::hsl(99.0, 0.66, 0.55);
@@ -47,9 +69,7 @@ fn spawn_stadium(
         components::OnGameScreen,
         PolylineBundle {
             polyline: PolylineHandle(polylines.add(Polyline { 
-                vertices: physics::determine_track_points(
-                    length, inner_radius, bend_sections
-                )
+                vertices: physics::determine_track_points(paths.0[0].clone())
             })),
             material: PolylineMaterialHandle(polyline_materials.add(
                 PolylineMaterial {
@@ -69,9 +89,7 @@ fn spawn_stadium(
         components::OnGameScreen,
         PolylineBundle {
             polyline: PolylineHandle(polylines.add(Polyline { 
-                vertices: physics::determine_track_points(
-                    length, radius_ratio * inner_radius, bend_sections
-                )
+                vertices: physics::determine_track_points(paths.0[paths.0.len() - 1].clone())
             })),
             material: PolylineMaterialHandle(polyline_materials.add(PolylineMaterial {
                 width: 3.,
@@ -84,23 +102,14 @@ fn spawn_stadium(
     ));
 
     // Spawn individual tracks
-    let ratio_increase = 1. / (num_tracks as f32 + 1.);
     let track_color = Color::hsl(35.0, 0.69, 0.32);
-    paths.0.clear();
+    let num_tracks = paths.0.len() - 2; // inner and outer paths
     for track_id in 0..num_tracks {
-        // Determine points
-        let ratio = 1. + (track_id as f32 + 1.) * ratio_increase;
-        let radius = inner_radius * ratio;
-        let vertices = physics::determine_track_points(
-            length, radius, bend_sections
-        );
-
-        // Spawn tracks
         commands.spawn((
             components::OnGameScreen,
             PolylineBundle {
                 polyline: PolylineHandle(polylines.add(Polyline { 
-                    vertices: vertices.clone()
+                    vertices: physics::determine_track_points(paths.0[track_id + 1].clone())
                 })),
                 material: PolylineMaterialHandle(polyline_materials.add(PolylineMaterial {
                     width: 3.,
@@ -111,9 +120,6 @@ fn spawn_stadium(
                 ..default()
             },
         ));
-
-        // Store points
-        paths.0.push(vertices);
     }
 }
 
@@ -130,7 +136,7 @@ fn spawn_players(
     
     // Iterate over player ids and spawn them
     for player_id in 0..num_players {
-        let starting_pos = &paths.0[player_id][0];
+        let starting_pos = &paths.0[player_id + 1][0];
         commands.spawn((
             components::OnGameScreen,
             components::Player{ 
@@ -166,11 +172,15 @@ fn move_players_along_tracks(
         player.distance += 250. * time.delta_secs();
 
         // Get player path
-        let path = &paths.0[player.handle];
+        let path = &paths.0[player.handle + 1];
 
         // Determine distance between last track point and the next one
-        let next_index = (player.pos_index + 1) % path.len();
+        let next_index = player.pos_index + 1;
         let mut last_point = path[player.pos_index];
+        if next_index == path.len() {
+            transform.translation = last_point;
+            continue;
+        }
         let mut next_point = path[next_index];
         let distance_to_next_point = next_point.distance(last_point);
 

--- a/rusting-raceway/src/physics.rs
+++ b/rusting-raceway/src/physics.rs
@@ -20,41 +20,12 @@ pub fn determine_bend_section_length(radius: f32, bend_sections: u32) -> f32 {
     (radius * PI) / bend_sections as f32
 }
 
-/// Determines stadium path from its length, radius and section size
-pub fn determine_track_points(length: f32, radius: f32, bend_sections: u32) -> Vec<Vec3> {
-    let incremental_rotation_angle = determine_incremental_rotation_angle(bend_sections);
-    let bend_section_length = determine_bend_section_length(radius, bend_sections);
+/// Determines stadium path from a player path
+pub fn determine_track_points(path: Vec<Vec3>) -> Vec<Vec3> {
+    // Make a copy of the path
+    let mut points = path.clone();
 
-    // We determine the inner points of the top left half and then reflect the results
-    // to obtain the other three quadrants
-    let mut points: Vec<Vec3> = Vec::new();
-
-    // Top section (left-half)
-    points.extend(vec![
-        Vec3::new(0.0, radius, 0.0), Vec3::new(-length / 2.0, radius, 0.0)
-    ]);
-
-    // Left section (top-half)
-    let mut angle = -180.0;
-    let mut position = Vec3 { x: -length / 2.0, y: radius, z: 0.0 };
-    // Since we only want the upper left quadrant, we only need to go up to half 
-    // the number of sections in the curve. To avoid backtracking, we start the loop at 2
-    for _ in (2..bend_sections).step_by(2) {
-        angle += incremental_rotation_angle;
-        let direction = Vec2::from_angle(angle.to_radians()).extend(0.0);
-        position += direction * bend_section_length;
-        points.push( position );
-    }
-
-    // Reflect along x axis to obtain bottom left quadrant
-    let mut reflections = points.clone();
-    reflections.reverse();
-    for pt in &mut reflections {
-        pt.y *= -1.0;
-    }
-    points.extend(reflections);
-
-    // Reflect along y axis to obtain remaining quadrants
+    // Reflect along y axis
     let mut reflections = points.clone();
     reflections.reverse();
     for pt in &mut reflections {
@@ -62,6 +33,55 @@ pub fn determine_track_points(length: f32, radius: f32, bend_sections: u32) -> V
     }
     points.extend(reflections);
 
-    // Return points
+    points
+}
+
+
+/// Determines a player's path along the stadium tracks
+/// with the starting point corresponding to a staggered position and some endpoint
+pub fn determine_player_path(
+    bend_sections: u32, 
+    start: Vec3,
+    end: Vec3, 
+    length: f32, 
+    radius: f32, 
+) -> Vec<Vec3> {
+    let incremental_rotation_angle = determine_incremental_rotation_angle(bend_sections);
+    let bend_section_length = determine_bend_section_length(radius, bend_sections);
+
+    // Top section from start point until left bend
+    let mut points: Vec<Vec3> = vec![ 
+        start, 
+        Vec3::new(-length / 2.0, radius, 0.0) 
+    ];
+
+    // Left bend from top to bend midpoint
+    let mut angle = -180.0;
+    let mut bend_position = Vec3::new(-length / 2.0, radius, 0.0);
+    let mut bend_points = Vec::new();
+    // We can obtain the rest of the bend by reflecting along the x axis.
+    // To avoid backtracking, we start the loop at 2
+    for _ in (2..bend_sections).step_by(2) {
+        angle += incremental_rotation_angle;
+        let direction = Vec2::from_angle(angle.to_radians()).extend(0.0);
+        bend_position += direction * bend_section_length;
+        bend_points.push( bend_position );
+    }
+
+    // Reflect the bend points to obtain the rest of the bend
+    let mut reflections = bend_points.clone();
+    reflections.reverse();
+    for pt in &mut reflections {
+        pt.y *= -1.0;
+    }
+    bend_points.extend(reflections);
+
+    // Add bend points
+    points.extend(bend_points);
+
+    // Lastly we add the endpoint
+    points.push(end);
+
+    // Return path points
     points
 }


### PR DESCRIPTION
 ## Summary
- Created a separate function which calculates the player paths and inserts the Paths resource
- Created a physics function for player paths and adapted the determine_track_points function to calculate the closed paths from the player paths
- Added a check to stop player from moving after reaching endpoint

## TODO
- Calculate starting staggered positions
- Improve on the end condition logic for player movement